### PR TITLE
Feature/40 stampcard integration

### DIFF
--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,16 +1,12 @@
 import { NextResponse } from "next/server";
-import { supabase } from "@/types/supabaseClient";
-import { COOKIE_NAME } from "@/constants";
 import { cookies } from "next/headers";
-import { createRouteHandlerClient, createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 export async function GET() {
-
-  // we use route handler client to remove the cookies required
 
   // enforce any type so typescript doesnt scream
   const cookieStore = (await cookies()) as any;
   const supabase = createRouteHandlerClient({cookies : () => cookieStore});
-  const supabaseUser = createClientComponentClient();
+
   // connect to DB to sign out current user
   try {
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,7 +76,6 @@ export default function Home() {
             </div>
             <div className="absolute left-[13vw] top-[11vh] z-3">
               <StampCardProto
-                color="yellow-400"
               />
             </div>
             <div className="absolute left-[3vw] top-[28vh] z-1">

--- a/app/stampcard/page.tsx
+++ b/app/stampcard/page.tsx
@@ -4,8 +4,9 @@ import axios, { AxiosError } from "axios";
 import Stampcard from "@/components/Stampcard";
 import type { StampType, StampProps } from "@/types/types";
 
+const exStamp: StampType = {id:1, date:'09-28'};
 const stamp : StampType = {id:1, date:'mm-dd'};
-const stamps : StampType[] = [stamp];
+const stamps : StampType[] = [exStamp, stamp, stamp, stamp, stamp, stamp, stamp, stamp, stamp, stamp];
 export default function Home() {
 
   return (

--- a/app/stampcard/page.tsx
+++ b/app/stampcard/page.tsx
@@ -6,7 +6,7 @@ import type { StampType, StampProps } from "@/types/types";
 
 const exStamp: StampType = {id:1, date:'09-28'};
 const stamp : StampType = {id:1, date:'mm-dd'};
-const stamps : StampType[] = [exStamp, stamp, stamp, stamp, stamp, stamp, stamp, stamp, stamp, stamp];
+const stamps : StampType[] = [stamp, stamp, stamp];
 export default function Home() {
 
   return (

--- a/components/Stampcard.tsx
+++ b/components/Stampcard.tsx
@@ -16,18 +16,30 @@ export type StampProps = {
 */
 export default function Stampcard({stamps} : StampProps) {
     return( 
-        <div className="relative w-[400px] h-[250px]">
+        <div className="relative w-[28vw] h-auto">
             <Image
               src={design}
               alt="Photo"
               className="object-cover rounded-lg"
               />
-            <div className="absolute inset-0 flex items-center justify-center">
+            <div className="absolute left-[2vw] w-[24vw] bottom-[12vw] flex flex-row justify-between">
               {/* please tinker with the width and height. 
                   please also make 10 copies for each stamp date, and comment the offsets for each date in the comments of your github request.
               
               */}
-              <p className="text-black text-xl font-bold px-4 py-2 rounded">
+              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
+                mm-dd
+              </p>
+              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
+                mm-dd
+              </p>
+              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
+                mm-dd
+              </p>
+              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
+                mm-dd
+              </p>
+              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
                 mm-dd
               </p>
             </div>

--- a/components/Stampcard.tsx
+++ b/components/Stampcard.tsx
@@ -16,7 +16,7 @@ export default function Stampcard({ stamps }: StampProps) {
         {stamps.slice(0, 5).map((stamp) => (
           <p
             key={stamp.id}
-            className="text-black italic text-[.9vw] border w-[3.8vw] text-center font-bold rounded h-[2vw] flex items-center justify-center"
+            className="text-black italic text-[.9vw] w-[3.8vw] text-center font-bold rounded h-[2vw] flex items-center justify-center"
           >
             {stamp.date}
           </p>

--- a/components/Stampcard.tsx
+++ b/components/Stampcard.tsx
@@ -12,11 +12,11 @@ export default function Stampcard({ stamps }: StampProps) {
       />
 
       {/* stamps 1–5 */}
-      <div className="absolute left-[2vw] w-[24vw] bottom-[12vw] flex flex-row justify-between">
+      <div className="absolute left-[2vw] w-[24vw] bottom-[12vw] flex flex-row gap-[1.26vw]">
         {stamps.slice(0, 5).map((stamp) => (
           <p
             key={stamp.id}
-            className="text-black italic text-[.9vw] w-[3.8vw] text-center font-bold rounded h-[2vw] flex items-center justify-center"
+            className="text-black italic text-[.9vw] border w-[3.8vw] text-center font-bold rounded h-[2vw] flex items-center justify-center"
           >
             {stamp.date}
           </p>
@@ -24,7 +24,7 @@ export default function Stampcard({ stamps }: StampProps) {
       </div>
 
       {/* stamps 6–10 */}
-      <div className="absolute left-[2vw] w-[24vw] bottom-[7vw] flex flex-row justify-between">
+      <div className="absolute left-[2vw] w-[24vw] bottom-[7vw] flex flex-row gap-[1.26vw]">
         {stamps.slice(5, 10).map((stamp) => (
           <p
             key={stamp.id}

--- a/components/Stampcard.tsx
+++ b/components/Stampcard.tsx
@@ -1,48 +1,39 @@
 import type { StampType, StampProps } from "@/types/types";
 import Image from "next/image";
-import design from '@/components/images/design-stampcard.png';
-/*
+import design from "@/components/images/design-stampcard.png";
 
-StampType is defined as:
-export type StampType = {
-  id: number;
-  date: string;
-};
+export default function Stampcard({ stamps }: StampProps) {
+  return (
+    <div className="relative w-[28vw] h-auto">
+      <Image
+        src={design}
+        alt="Stamp Card Design"
+        className="object-cover rounded-lg"
+      />
 
-StampProps is defined as:
-export type StampProps = {
-    stamps: StampType[];
-}
-*/
-export default function Stampcard({stamps} : StampProps) {
-    return( 
-        <div className="relative w-[28vw] h-auto">
-            <Image
-              src={design}
-              alt="Photo"
-              className="object-cover rounded-lg"
-              />
-            <div className="absolute left-[2vw] w-[24vw] bottom-[12vw] flex flex-row justify-between">
-              {/* please tinker with the width and height. 
-                  please also make 10 copies for each stamp date, and comment the offsets for each date in the comments of your github request.
-              
-              */}
-              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
-                mm-dd
-              </p>
-              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
-                mm-dd
-              </p>
-              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
-                mm-dd
-              </p>
-              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
-                mm-dd
-              </p>
-              <p className="text-black text-[.6vw] w-[3.8vw] text-center font-bold px-4 rounded border-1 h-[2vw]">
-                mm-dd
-              </p>
-            </div>
+      {/* stamps 1–5 */}
+      <div className="absolute left-[2vw] w-[24vw] bottom-[12vw] flex flex-row justify-between">
+        {stamps.slice(0, 5).map((stamp) => (
+          <p
+            key={stamp.id}
+            className="text-black italic text-[.9vw] w-[3.8vw] text-center font-bold rounded h-[2vw] flex items-center justify-center"
+          >
+            {stamp.date}
+          </p>
+        ))}
+      </div>
+
+      {/* stamps 6–10 */}
+      <div className="absolute left-[2vw] w-[24vw] bottom-[7vw] flex flex-row justify-between">
+        {stamps.slice(5, 10).map((stamp) => (
+          <p
+            key={stamp.id}
+            className="text-black italic text-[.9vw] w-[3.8vw] text-center font-bold rounded h-[2vw] flex items-center justify-center"
+          >
+            {stamp.date}
+          </p>
+        ))}
+      </div>
     </div>
-    )
+  );
 }

--- a/components/root/Section2.tsx
+++ b/components/root/Section2.tsx
@@ -28,7 +28,7 @@ export function StampProto(){
     )
 }
 
-export function StampCardProto({color='yellow-400px', claim=true}) {
+export function StampCardProto({color='yellow-400', claim=true}) {
   const stamps = Array.from({length: 10}).map((_, index) => {
     return (
       <div key={index} className="w-[257px] h-[22px] flex justify-center">


### PR DESCRIPTION
# Summary
I aligned the stamp dates to the image. 

The image, the font, and all the stamps scale with the viewport width

In /app/stampcard/page.tsx, I hard coded the stamps array to fill all the boxes. In production, I guess all the ids will be unique and ordered correctly. 

In stampcard.tsx, I used an array slice to divide the stamps between the top and bottom rows. 
The row dimensions are: width: 24vw height: 2vw
Top row alignment: left-[2vw], bottom-[12vw] 
Bot. row alignment: left-[2vw], bottom-[7vw]

Each stamp is [3.8vw] in width and I used gap-[1.26] between each box.

The text is [.9vw]. The textbox itself is [2vw] in height

# Additional Information
1920x1080:
<img width="538" height="379" alt="image" src="https://github.com/user-attachments/assets/4f6afeb2-95b2-42a6-819b-f0cb9637268b" />
1440 x whatever:
<img width="283" height="198" alt="image" src="https://github.com/user-attachments/assets/9cc43ca4-f5ef-44d6-a20f-5b1dbf97cb49" />
A little filled:
<img width="540" height="381" alt="image" src="https://github.com/user-attachments/assets/ac587be6-fd97-4849-946d-b317a75d2d0d" />
More filled:
<img width="538" height="383" alt="image" src="https://github.com/user-attachments/assets/5c6d62aa-b073-4a23-b35b-a15b59e2d66e" />
Reference image:
<img width="898" height="638" alt="image" src="https://github.com/user-attachments/assets/5a2a3643-5047-400b-9a9a-4b3d922eab11" />


Closes #40 
